### PR TITLE
Removed dependency on the deprecated `tempfile` command

### DIFF
--- a/pnglatex
+++ b/pnglatex
@@ -51,8 +51,7 @@ function box {
 
 # Remove temporary files.
 function clean {
-    local BNAME=${TEXFILE%.tex}
-    rm -f $TEXFILE $BNAME.aux $BNAME.dvi $BNAME.log
+    rm -rf $TMPDIR
 }
 
 # Collapse multiple subsequent spaces in a string.
@@ -116,13 +115,8 @@ function generate {
         exit 1
     fi
 
-    TMPDIR=/tmp/me/mneri/pnglatex
-
-    if [ ! -d $TMPDIR ]; then
-        mkdir -p $TMPDIR
-    fi
-
-    TEXFILE=$(tempfile -d $TMPDIR -p f -s .tex)
+    TMPDIR="$(mktemp -d)"
+    TEXFILE="$(mktemp -p $TMPDIR fXXX.tex)"
 
     if [ "$ENVIRONMENT" = '$' ] || [ "$ENVIRONMENT" = '$$' ]; then
         BEGINENV=$ENVIRONMENT


### PR DESCRIPTION
This changes the script to use `mktemp` in place of `tempfile` as the former is in `coreutils` and the latter is considered to be deprecated (but is also frequently a wrapper around `mktemp`). `mktemp` is also able to create directories so the hardcoded `/tmp/me/mneri/pnglatex/` folder is no longer needed.

More on the history:
https://stackoverflow.com/questions/18716658/whats-the-difference-between-tempfile-and-mktemp#18717518